### PR TITLE
Magisk v20.3+ Core Only Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To use it...
 
 1) Restore your stock `boot.img`, so that you can boot your phone
 2) Open magisk manager settings and set the update channel to `https://raw.githubusercontent.com/ammmze/magisk-recovery/master/custom.json`
-3) On magisk home screen refresh it and it should show the `19.999` version as being the latest one. This is really Magisk 20.0 but patched to boot in Core Only
+3) On magisk home screen refresh it and it should show the `20.299` version as being the latest one. This is really Magisk 20.3+ (Built at commit fbe776db0bdfcbf3b1052381ca43382a61175aa5) but patched to boot in Core Only
 4) Install this custom magisk as normal and your phone should be able to boot with magisk in core only mode
 5) Disable/uninstall any magisk module(s) causing problems
 6) Set the update channel back to stable in magisk manager
@@ -41,12 +41,12 @@ The gist of the process is this:
 
 ### Clone the repo
 
-First you'll want to clone the repo and switch to the latest release tag (which currently is `v20.0`)...
+First you'll want to clone the repo and switch to the latest release tag (which currently is `v20.3+`)...
 
 ```bash
 git clone https://github.com/topjohnwu/Magisk.git
 cd Magisk
-git checkout v20.0
+git checkout v20.3+
 ```
 
 ### Environment variable locations
@@ -55,7 +55,7 @@ For me those environment variables look like this...
 
 ```bash
 export ANDROID_HOME=/Users/trogdor/Android/sdk
-export ANDROID_NDK_HOME=/Users/trogdor/Android/sdk/ndk/20.0.5594570
+export ANDROID_NDK_HOME=/Users/trogdor/Android/sdk/ndk/20.3+.5594570
 ```
 
 > You'll want to make sure there are no spaces in those paths. Initially I had a space in one of the directory names and at some point the build blew up on me.
@@ -72,7 +72,7 @@ In the end, here's what my `config.props` looked like:
 
 ```properties
 # The version name and version code of Magisk
-version=19.999
+version=20.299
 versionCode=19999
 
 # The version name and version code of Magisk Manager
@@ -141,10 +141,10 @@ Here's what my `custom.json` looks like:
     "note": "https://raw.githubusercontent.com/topjohnwu/Magisk/59fd38bbf810c81076a1f9b16bc5a0071581b9e7/app/src/main/res/raw/changelog.md"
   },
   "uninstaller": {
-    "link": "https://github.com/topjohnwu/Magisk/releases/download/v20.0/Magisk-uninstaller-20191011.zip"
+    "link": "https://github.com/topjohnwu/Magisk/releases/download/v20.3+/Magisk-uninstaller-20191011.zip"
   },
   "magisk": {
-    "version": "19.999",
+    "version": "20.299",
     "versionCode": "19999",
     "link": "http://192.168.0.117:8000/magisk-debug.zip",
     "note": "https://raw.githubusercontent.com/topjohnwu/magisk_files/2d7ddefbe4946806de1875a18247b724f5e7d4a0/notes.md",

--- a/custom.json
+++ b/custom.json
@@ -1,18 +1,18 @@
 {
   "app": {
-    "version": "7.3.5",
-    "versionCode": "243",
-    "link": "https://github.com/topjohnwu/Magisk/releases/download/manager-v7.3.5/MagiskManager-v7.3.5.apk",
-    "note": "https://raw.githubusercontent.com/topjohnwu/Magisk/59fd38bbf810c81076a1f9b16bc5a0071581b9e7/app/src/main/res/raw/changelog.md"
+    "version": "7.5.1",
+    "versionCode": "267",
+    "link": "https://github.com/topjohnwu/Magisk/releases/download/manager-v7.5.1/MagiskManager-v7.5.1.apk",
+    "note": "https://raw.githubusercontent.com/topjohnwu/Magisk/7db523071d662dcc8eb187e3cbae141c716ba045/app/src/main/res/raw/changelog.md"
   },
   "uninstaller": {
-    "link": "https://github.com/topjohnwu/Magisk/releases/download/v20.0/Magisk-uninstaller-20191011.zip"
+    "link": "https://github.com/topjohnwu/Magisk/releases/download/v20.3/Magisk-uninstaller-20200110.zip"
   },
   "magisk": {
-    "version": "19.999",
-    "versionCode": "19999",
-    "link": "https://github.com/ammmze/magisk-recovery/releases/download/19.999/magisk-debug.zip",
-    "note": "https://raw.githubusercontent.com/topjohnwu/magisk_files/2d7ddefbe4946806de1875a18247b724f5e7d4a0/notes.md",
+    "version": "20.299",
+    "versionCode": "20299",
+    "link": "https://github.com/ajayyy/magisk-recovery/releases/download/20.299999/magisk-debug.zip",
+    "note": "https://raw.githubusercontent.com/topjohnwu/magisk_files/4f33b2656fd9ddc27fc7f9be4e83a747084ca908/notes.md",
     "md5": "088fb6545e7042a4939bda7d21423b8b"
   }
 }


### PR DESCRIPTION
Your version wasn't working on my OnePlus 7T, so I decided to build an updated version. This one is based on commit fbe776db0bdfcbf3b1052381ca43382a61175aa5.

To use before this PR is merged, set your update channel to: `https://raw.githubusercontent.com/ajayyy/magisk-recovery/magisk-latest-jan27/custom.json`